### PR TITLE
[IMP] Enhancing Inventory Performance Reports

### DIFF
--- a/gse_inventory_reports/__init__.py
+++ b/gse_inventory_reports/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+# from . import controllers
+from . import models

--- a/gse_inventory_reports/__manifest__.py
+++ b/gse_inventory_reports/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "Gse Inventory Report",
+    "summary": """
+        Customisation of Gse Inventory Report module for GoShop Energy""",
+    "description": """
+    """,
+    "author": "Magana Mwinja Asiati",
+    "website": "https://github.com/GoShop-Energy/field-service",
+    "category": "Customizations",
+    "version": "0.1.8.7",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "stock",
+        "stock_enterprise"
+    ],
+    "data": [ ],
+    "images": [ ],
+    "assets": {"web.assets_backend": []},
+}

--- a/gse_inventory_reports/models/__init__.py
+++ b/gse_inventory_reports/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import stock_report

--- a/gse_inventory_reports/models/stock_report.py
+++ b/gse_inventory_reports/models/stock_report.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models, _
+
+
+class StockReport(models.Model):
+    _inherit = 'stock.report'
+    
+    location_id = fields.Many2one(
+        'stock.location', 'Source Location',
+        readonly=True,
+        auto_join=True,
+        index=True,
+        required=True,
+        check_company=True,
+        help="Sets a location if you produce at a fixed location. This can be a partner location if you subcontract the manufacturing operations."
+    )
+    def _select(self):
+        select_str = """
+            sm.id as id,
+            sp.name as picking_name,
+            sm.location_id as location_id,
+            sp.date_done as date_done,
+            sp.creation_date as creation_date,
+            sp.scheduled_date as scheduled_date,
+            sp.partner_id as partner_id,
+            sp.is_backorder as is_backorder,
+            sp.delay as delay,
+            sp.delay > 0 as is_late,
+            sp.cycle_time as cycle_time,
+            spt.code as picking_type_code,
+            spt.name as operation_type,
+            p.id as product_id,
+            sm.reference as reference,
+            sm.picking_id as picking_id,
+            sm.state as state,
+            sm.product_qty as product_qty,
+            sm.company_id as company_id,
+            cat.id as categ_id
+        """
+
+        return select_str


### PR DESCRIPTION
### Rationale
Improve the inventory performance reports within our system by incorporating an additional dimension to analyze performance by warehouse. While current statistics by type of operation offer valuable insights in a single warehouse setting, our multi-warehouse operations require a more granular level of analysis to better understand performance variations across different locations.

### Specification
Add 'Source Location' to Performance Analysis: Integrate the 'Source Location' field into the inventory performance reports. This addition will enable filtering and analysis of inventory movements and performance metrics by specific warehouses, providing a clearer view of each warehouse's efficiency, stock management, and operational challenges.
Add Destination Location to performance Analysis

![image](https://github.com/GoShop-Energy/lou/assets/95297251/395e389e-c6d7-4556-b802-a470253ce898)

