### PR TITLE
Prevent bom edition 

### DIFF
--- a/gse_bom/__init__.py
+++ b/gse_bom/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+# from . import controllers
+from . import models

--- a/gse_bom/__manifest__.py
+++ b/gse_bom/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "Gse BOM",
+    "summary": """
+       Prevent BOM edition after sale""",
+    "description": """
+    """,
+    "author": "Magana Mwinja Asiati",
+    "category": "Customizations",
+    "version": "0.1.8.7",
+    "license": "LGPL-3",
+    "depends": [
+        "stock",
+        "stock_enterprise",
+        "mrp",
+    ],
+    "data": [ ],
+    "images": [ ],
+    "assets": {"web.assets_backend": []},
+}

--- a/gse_bom/models/__init__.py
+++ b/gse_bom/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import mrp_bom

--- a/gse_bom/models/mrp_bom.py
+++ b/gse_bom/models/mrp_bom.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, api, _
+from odoo.exceptions import UserError
+
+class CustomMrpBom(models.Model):
+    _inherit = 'mrp.bom'
+
+    @api.onchange('bom_line_ids', 'product_qty')
+    def onchange_bom_structure(self):
+           if self.type == 'phantom' and self._origin and self.env['stock.move'].search([('bom_line_id', 'in', self._origin.bom_line_ids.ids)], limit=1):
+                raise UserError(_(   'The product has already been used at least once, editing its structure may lead to undesirable behaviors. '
+                'You should rather archive the product and create a new one with a new bill of materials.'))
+            
+   


### PR DESCRIPTION
## Rationale
To maintain data consistency, it's crucial to restrict the editing of the Bill of Materials (BOM, kit) once a product is sold, as post-sale alterations can lead to discrepancies.

## Specification
So far, there is 'only' a warning, we need a blocking message.