### PR TITLE
[IMP] Restriction of Tax Application to Selected Journals

### DIFF
--- a/gse_tax_journal/__init__.py
+++ b/gse_tax_journal/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/gse_tax_journal/__manifest__.py
+++ b/gse_tax_journal/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "Gse Tax & Journal",
+    "summary": """
+        Customizations pour Goshop Energy""",
+    "description": """
+    """,
+    "category": "Customizations",
+    "version": "1.0",
+    "license": "LGPL-3",
+    "depends": [
+        "account",
+        "mail",
+    ],
+    "data": [
+        "views/account_tax.xml",
+    ],
+    "assets": {"web.assets_backend": []},
+}

--- a/gse_tax_journal/models/__init__.py
+++ b/gse_tax_journal/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import account_tax
+from . import account_move

--- a/gse_tax_journal/models/account_move.py
+++ b/gse_tax_journal/models/account_move.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+from odoo.exceptions import ValidationError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def action_post(self):
+        res = super(AccountMove, self).action_post()
+        move_line = self.env["account.move.line"].search([("move_id", "=", self.id)])
+        for line in move_line:
+            for tax in line.tax_ids:
+                transformed_args = [arg.id for arg in tax.allowed_journal]
+                if self.journal_id.id not in transformed_args and tax.allowed_journal:
+                    raise ValidationError(
+                        f"{tax.name} - This tax is not allowed for this journal : {self.journal_id.name}."
+                    )
+        return res

--- a/gse_tax_journal/models/account_tax.py
+++ b/gse_tax_journal/models/account_tax.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    allowed_journal = fields.Many2many("account.journal", string="Allowed Journals")

--- a/gse_tax_journal/views/account_tax.xml
+++ b/gse_tax_journal/views/account_tax.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_tax_journal_form" model="ir.ui.view">
+                <field name="name">account.tax.journal.form</field>
+                <field name="inherit_id" ref="account.view_tax_form" />
+                <field name="priority">99</field>
+                <field name="model">account.tax</field>
+                <field name="arch" type="xml">
+                    <xpath expr="//form//sheet//group//group//field[@name='active']" position="after">
+                        <field name="allowed_journal" widget="many2many_tags"/>
+                    </xpath>
+                </field>
+    </record>
+</odoo>


### PR DESCRIPTION
On this branch, I made changes based on the description below.

### Rationale 🎯 :

To enhance the accounting app by introducing a feature that allows limiting the use of specific taxes to selected journals. This feature will help in enforcing financial controls.

### Specification 👀  :

1. **Tax-Journal Linking**:

A new Many2Many field shall be added to the tax configuration (in the Accounting module) to associate specific taxes with selected journals.
The field will be labeled as "Allowed Journals" and will list all available journals in the system for selection.


2. **Default Behavior**:

By default, if the "Allowed Journals" field is not populated for a tax, the system shall allow its use in all journals.


3. **Invoice Validation Restriction**:

During the validation of an invoice (not a Sales Order), the system shall check if the taxes applied on the invoice are permitted for the journal associated with the invoice.
If an invoice includes any tax that is not linked to the invoice's journal (i.e., the tax is not among the allowed taxes for that journal), the system shall prevent the validation of the invoice.
A clear error message shall be displayed, indicating the reason for the validation failure. The message should specify which tax(es) are not allowed for the journal.


4. **User Interface Adjustments**:

The user interface for tax configuration shall be adjusted to include the new "Allowed Journals" field.
Appropriate tooltips or help text shall be provided to guide users in using this new feature.


5. **Reporting and Logging**:

All attempts to validate invoices with unauthorized tax-journal combinations shall be logged for audit purposes.
The system shall provide reports to administrators showing instances of validation blocks due to this restriction.