### PR TITLE
[IMP] gse_conversion: Display Conversion USD to CDF

### DIFF
--- a/gse_display_Conversion_USD/__init__.py
+++ b/gse_display_Conversion_USD/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+# from . import controllers
+from . import models

--- a/gse_display_Conversion_USD/__manifest__.py
+++ b/gse_display_Conversion_USD/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "Gse display conversion USD ",
+    "summary": """
+        create a new module  conversion in USD for GoShop Energy""",
+    "description": """
+    """,
+    "author": "Magana Mwinja Asiati",
+    "depends": [
+        "sale",
+        "account",
+        "gse_custo"
+    ],
+    "data": [ 
+        "views/sale_order.xml",
+        "views/account_move.xml",
+        "views/report_templates.xml",
+    ],
+    "images": [ ],
+    "assets": {"web.assets_backend": []},
+}

--- a/gse_display_Conversion_USD/models/__init__.py
+++ b/gse_display_Conversion_USD/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import sale_order
+from . import account_move

--- a/gse_display_Conversion_USD/models/account_move.py
+++ b/gse_display_Conversion_USD/models/account_move.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    company_currency_amount = fields.Monetary(string='Amount in Company Currency',compute='_compute_company_currency_amount', 
+        currency_field='company_currency_id',)
+    exchange_rate = fields.Float(string='Exchange Rate', compute='_compute_rate')
+    exchange_rate_store = fields.Float(string='Exchange Rate', store=True)
+    is_same_curr = fields.Boolean(string='same currency')
+    company_currency_id = fields.Many2one(related='company_id.currency_id', string='Company Currency', required = True)
+
+
+    @api.depends('currency_id', 'company_id.currency_id', 'amount_total', 'exchange_rate' )
+    def _compute_company_currency_amount(self):
+        for order in self:
+            if  order.currency_id != order.company_id.currency_id:
+                order.company_currency_amount = order.amount_total * order.exchange_rate 
+                
+                order.is_same_curr = False
+            else:
+                order.company_currency_amount = order.amount_total
+                order.is_same_curr = True
+
+    def _compute_rate(self):
+        for order in self:
+            
+            price_list = self.env["res.currency"].search([("name", "=", order.currency_id.name)])
+            last_recod_rate = price_list.rate_ids.sorted('name', reverse=True)[0] if price_list.rate_ids else False
+            rate_price_list =  last_recod_rate.inverse_company_rate if last_recod_rate != False else 1.0
+            
+            if order.state != "sale":
+                order.exchange_rate = rate_price_list
+                order.exchange_rate_store = rate_price_list
+            else:
+                order.exchange_rate = order.exchange_rate_store

--- a/gse_display_Conversion_USD/models/sale_order.py
+++ b/gse_display_Conversion_USD/models/sale_order.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    company_currency_amount = fields.Monetary(string='Amount in Company Currency',compute ='_compute_company_currency_amount', 
+        currency_field='company_currency_id',)
+    exchange_rate = fields.Float(string='Exchange Rate', compute ='_compute_rate')
+    exchange_rate_store = fields.Float(string='Exchange Rate', store=True)
+    is_same_curr = fields.Boolean(string='same currency')
+    company_currency_id = fields.Many2one(related='company_id.currency_id', string='Company Currency', required = True)
+
+    @api.depends('currency_id', 'company_id.currency_id', 'amount_total', 'exchange_rate' )
+    def _compute_company_currency_amount(self):
+        for order in self:
+            if  order.currency_id != order.company_id.currency_id:
+                order.company_currency_amount = order.amount_total * order.exchange_rate 
+                
+                order.is_same_curr = False
+            else:
+                order.company_currency_amount = order.amount_total
+                order.is_same_curr = True
+
+    def _compute_rate(self):
+        for order in self:
+            
+            price_list = self.env["res.currency"].search([("name", "=", order.currency_id.name)])
+            last_recod_rate = price_list.rate_ids.sorted('name', reverse=True)[0] if price_list.rate_ids else False
+            rate_price_list =  last_recod_rate.inverse_company_rate if last_recod_rate != False else 1.0
+            
+            if order.state != "sale":
+                order.exchange_rate = rate_price_list
+                order.exchange_rate_store = rate_price_list
+            else:
+                order.exchange_rate = order.exchange_rate_store
+

--- a/gse_display_Conversion_USD/views/account_move.xml
+++ b/gse_display_Conversion_USD/views/account_move.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<odoo>
+    <record model="ir.ui.view" id="view_move_form_inherit_assia">
+        <field name="name">account.move.form.inherit.assia</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='amount_total']" position="after">
+                 <field name="is_same_curr" invisible="True"/>
+                 <field name="company_currency_amount"  options="{'currency_field': 'company_currency_id'}"
+                   attrs="{'invisible': [('is_same_curr', '=', True)]}"/>
+
+                 <field name="company_currency_id" invisible="1" />
+                 <field name="exchange_rate"  attrs="{'invisible': [('is_same_curr', '=', True)]}" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/gse_display_Conversion_USD/views/report_templates.xml
+++ b/gse_display_Conversion_USD/views/report_templates.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<odoo>
+    <data>
+        <template id="report_saleorder_document_customer" inherit_id="sale.report_saleorder_document">
+            <xpath expr="//div[@name='so_total_summary']//table" position="inside">
+             <t t-if="doc.is_same_curr == False">
+                <tr class="border-black o_total">   
+                    <td><strong>Exchange Rate</strong></td>
+                    <td class="text-end">
+                            <span t-field="doc.exchange_rate"/>
+                    </td>
+                </tr>
+                <tr class="border-black o_total">
+                    <td><strong>Amount in Company Currency</strong></td>
+                    <td class="text-end">
+                            <span t-field="doc.company_currency_amount"/>
+                    </td>
+                </tr>
+             </t>
+            </xpath>
+        </template>
+        <template id="report_saleorder_document_copy_assia" inherit_id="gse_custo.report_saleorder_document_copy">
+            <xpath expr="//div[@name='so_total_summary']//table" position="inside">
+             <t t-if="doc.is_same_curr == False">
+                <tr class="border-black o_total">   
+                    <td><strong>Exchange Rate</strong></td>
+                    <td class="text-end">
+                            <span t-field="doc.exchange_rate"/>
+                    </td>
+                </tr>
+                <tr class="border-black o_total">
+                    <td><strong>Amount in Company Currency</strong></td>
+                    <td class="text-end">
+                            <span t-field="doc.company_currency_amount"/>
+                    </td>
+                </tr>
+             </t>
+            </xpath>
+        </template>
+        <template id="report_invoice_document_assia" inherit_id="account.report_invoice_document">
+            <xpath expr="//div[@id='total']//table" position="inside">
+             <t t-if="o.is_same_curr == False">
+                <tr class="border-black o_total">   
+                    <td><strong>Exchange Rate</strong></td>
+                    <td class="text-end">
+                            <span t-field="o.exchange_rate"/>
+                    </td>
+                </tr>
+                <tr class="border-black o_total">
+                    <td><strong>Amount in Company Currency</strong></td>
+                    <td class="text-end">
+                            <span t-field="o.company_currency_amount"/>
+                    </td>
+                </tr>
+             </t>
+            </xpath>
+        </template>
+
+        
+    </data>
+</odoo>

--- a/gse_display_Conversion_USD/views/sale_order.xml
+++ b/gse_display_Conversion_USD/views/sale_order.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<odoo>
+    <record model="ir.ui.view" id="view_order_form_inherit_assia">
+        <field name="name">sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='tax_totals']" position="after">
+                <field name="is_same_curr" invisible="True"/>
+                 <field name="company_currency_amount"  options="{'currency_field': 'company_currency_id'}"
+                   attrs="{'invisible': [('is_same_curr', '=', True)]}"/>
+
+                 <field name="company_currency_id" invisible="1" />
+                <field name="exchange_rate"  attrs="{'invisible': [('is_same_curr', '=', True)]}" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Rationale

Display the amount of the SO in USD

Specification

If the currency of the pricelist used on the SO is different from the currency of the company,

display the amount in the currency of the company 


![image](https://github.com/GoShop-Energy/lou/assets/95297251/70b01b9d-8536-4733-86d6-8d17e0472e70)



The total in USD is computed when the total of the SO is changed. 

Once the SO is confirmed, the rate used is the one on the day of the confirmation.

If the SO is edited afterwards (cancel > back to quotation), recompute the total.



On the SO printed, display the amount on USD and the rate below the total price


![image](https://github.com/GoShop-Energy/lou/assets/95297251/4cc3c86a-2b7f-4f3a-b7cf-67eb3cca7d46)



Same on the invoices