### PR TITLE
[IMP] res.users: add job position

### DIFF
--- a/gse_hr/__init__.py
+++ b/gse_hr/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/gse_hr/__manifest__.py
+++ b/gse_hr/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "gse_hr",
+    'summary': """
+        Customizations pour Goshop Energy""", 
+    'author': "Benjamin Kisenge",
+    'website': "http://www.benkis.com", 
+    'category': 'Customizations',
+    'version': '0.1.8.6',
+    'license': 'LGPL-3',
+    'depends': [
+        'base',
+        'hr'
+    ], 
+    'data': [
+        'views/res_users.xml',
+    ]
+}

--- a/gse_hr/models/__init__.py
+++ b/gse_hr/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import res_users

--- a/gse_hr/models/res_users.py
+++ b/gse_hr/models/res_users.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    job_id = fields.Many2one('hr.job', compute='_compute_job_id',
+        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", string='Job Position')
+
+    def _compute_job_id(self):
+        for user in self:
+            user.job_id = user.employee_ids.job_id

--- a/gse_hr/views/res_users.xml
+++ b/gse_hr/views/res_users.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<odoo>
+    <record id="gse_user_form" model="ir.ui.view">
+        <field name="name">gse.user.form</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="priority">16</field>
+        <field name="arch" type="xml">
+            <xpath expr="//form//group" position="inside">
+                <field name="job_id" />
+            </xpath>
+        </field>
+    </record> 
+
+    <record id="gse_user_tree" model="ir.ui.view">
+        <field name="name">gse.user.tree</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_tree"/>
+        <field name="priority">16</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='state']" position="before">
+                <field name="job_id" />
+             </xpath>
+        </field>
+    </record> 
+</odoo>


### PR DESCRIPTION
### Rationale ♻️ 

When managing a sizable organization, it's impractical to memorize every employee and their respective roles. As a database administrator, my familiarity lies more with access rights linked to job positions rather than individual names. Consequently, identifying whether a user possesses the appropriate access rights directly from the re.users form proves challenging. Integrating the user's job position into the re.users form could significantly streamline this process. Currently, to verify a user's access rights, one must navigate away from the user form to the employee smart/stat button to check their job position, then return to the user form to confirm the access rights. Incorporating this feature would enhance efficiency and accuracy in managing access rights. 


### Specification 🎯 

If the user has multiple employee, see the job position  from the selected company. If more than one company selected, see the job position from the active one.