### PR TITLE
[IMP] Include Quantity on Accounting Entries

### DIFF
--- a/gse_account/__init__.py
+++ b/gse_account/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+# from . import controllers
+from . import models

--- a/gse_account/__manifest__.py
+++ b/gse_account/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "GSE Account",
+    "summary": """
+        Customisation of Account module for GoShop Energy""",
+    "description": """
+    """,
+    "author": "Benjamin Kisenge",
+    "website": "https://dev--glowing-faun-e9789d.netlify.app",
+    "category": "Customizations",
+    "version": "0.1.8.7",
+    "license": "LGPL-3",
+    "depends": [
+        "stock_account",
+    ],
+    "data": [
+        "views/move_views.xml",
+    ],
+}

--- a/gse_account/models/__init__.py
+++ b/gse_account/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/gse_account/models/account_move.py
+++ b/gse_account/models/account_move.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    is_valuation_move = fields.Boolean("Is Invetory Valuation", compute='_compute_is_valuation_move')
+
+    @api.depends('journal_id')
+    def _compute_is_valuation_move(self):
+        for move in self:
+            move.is_valuation_move = move.journal_id.name == 'Inventory Valuation'
+             

--- a/gse_account/views/move_views.xml
+++ b/gse_account/views/move_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_move_gse" model="ir.ui.view">
+        <field name="name">view.account.move.gse</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+             <data>
+                <xpath expr="//form[1]/sheet[1]/notebook[1]/page[@name='aml_tab']/field[@name='line_ids']/tree[1]/field[@name='name']" position="after">
+                    <field name="product_id" optional="show"  attrs="{'column_invisible': [('parent.is_valuation_move', '=', False)]}"/>
+                    <field name="quantity" optional="show"  attrs="{'column_invisible': [('parent.is_valuation_move', '=', False)]}"/>
+                    <field name="product_uom_category_id" invisible="1"/>
+                    <field name="product_uom_id" optional="show"  attrs="{'column_invisible': [('parent.is_valuation_move', '=', False)]}"/>
+                </xpath>
+
+                <xpath expr="//form[1]//div[@name='journal_div']" position="after">
+                    <field name="is_valuation_move"  invisible="1"/>
+                </xpath>
+            </data>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
### Rationale
Extend the stock management functionality to include the product and quantity of items on the corresponding accounting entries created during stock movements under the Average Cost (AVCO) method with continuous inventory valuation.

### Spec
Add on account.move.line the product and the quantity, fields should be stored to allow group and filter

![Screenshot 2024-04-23 at 09 12 15](https://github.com/GoShop-Energy/lou/assets/80458199/1de685cb-c703-47b8-99b1-dda95cb98e22)
