### PR TITLE
[IMP] gse_field_service: prevent field edition

### DIFF
--- a/gse_industry_fsm/models/project.py
+++ b/gse_industry_fsm/models/project.py
@@ -22,6 +22,7 @@ class ProjectTask(models.Model):
     delivery_count = fields.Integer(related="sale_order_id.delivery_count")
     picking_ids = fields.One2many(related="sale_order_id.picking_ids")
     partner_service_id = fields.Many2one("res.partner", string="Service Location" , readonly=False)
+    can_edit_form = fields.Boolean(string="Can Edit Form", compute="_compute_can_edit_form")
 
     def action_view_delivery(self):
         return self._get_action_view_picking(self.picking_ids)
@@ -58,3 +59,11 @@ class ProjectTask(models.Model):
     def onchange_partner_service_id(self):
         for task in self:
             task.partner_service_id = task.partner_id.address_get(['field_service'])['field_service'] if task.partner_id else False
+
+
+    def _compute_can_edit_form(self):
+        for task in self:
+            if self.env.user.user_has_groups("gse_access_rights.group_fsm_planner") or self.env.user.user_has_groups("industry_fsm.group_fsm_manager"):
+                task.can_edit_form = True
+            else:
+                task.can_edit_form = False

--- a/gse_industry_fsm/views/project_task_views.xml
+++ b/gse_industry_fsm/views/project_task_views.xml
@@ -25,11 +25,18 @@
                         modifiers="{&quot;required&quot;: [[&quot;is_fsm&quot;, &quot;=&quot;, true]]}"
                         can_create="true"
                         can_write="true"
-                        />  
+                        attrs="{'readonly': [('can_edit_form', '=', False)]}"
+                        /> 
+                    <field name="can_edit_form" invisible="1" />
                 </xpath>
 
                 <xpath expr="//form//group//field[@name='partner_id']" position="replace">
-                    <field name="partner_id" widget="res_partner_many2one" class="o_task_customer_field"/>  
+                    <field 
+                        name="partner_id" 
+                        widget="res_partner_many2one" 
+                        class="o_task_customer_field"
+                        attrs="{'readonly': [('can_edit_form', '=', False)]}"
+                    />  
                 </xpath>
 
                 <xpath expr="//label[@for='action_fsm_navigate']" position="replace">
@@ -51,6 +58,48 @@
                         attrs="{'invisible': [('delivery_count', '=', 0)]}" groups="stock.group_stock_user">
                         <field name="delivery_count" widget="statinfo" string="Delivery"/>
                     </button>
+                </xpath>
+
+                <xpath expr="//field[@name='project_id']" position="attributes">
+                     <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
+                </xpath>
+                
+                <!-- <xpath expr="//field[@name='name']" position="attributes">
+                     <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
+                </xpath> -->
+
+                <xpath expr="//field[@name='worksheet_template_id']" position="attributes">
+                     <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
+                </xpath>
+
+                <xpath expr="//field[@name='user_ids']" position="attributes">
+                     <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
+                </xpath>
+
+                <xpath expr="//field[@name='partner_phone']" position="attributes">
+                     <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
+                </xpath>
+                
+                <xpath expr="//field[@name='tag_ids']" position="attributes">
+                     <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
+                </xpath>  
+
+                <xpath expr="//field[@name='planned_date_begin']" position="attributes">
+                     <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
+                </xpath>  
+            </field>
+        </record>
+
+        <record id="gse_view_task_form2_inherit_sale_timesheet" model="ir.ui.view">
+            <field name="name">gse.view.task.form2.inherit</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="sale_project.view_sale_project_inherit_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='sale_line_id'][1]" position="attributes">
+                   <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='sale_line_id'][2]" position="attributes">
+                   <attribute name="attrs">{'readonly': [('can_edit_form', '=', False)]}</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
### Rationale
Prevent field edition by users. 

### Specification
Group "Field Service > User" can't edit the field from the header (see in pink). Only available for Field Service > Planner and Admin