### PR TITLE
[IMP] account_approval: allow discount from pricelist

### DIFF
--- a/gse_account/models/account_move.py
+++ b/gse_account/models/account_move.py
@@ -17,3 +17,4 @@ class AccountMove(models.Model):
         if self.company_id.use_custom_msg and self.company_id.use_custom_msg and self.use_custom_msg and gse_template: 
             return next(iter(gse_template.get_external_id().values()), None)
         return res
+    # ...


### PR DESCRIPTION
### Rationale 🔴 

With the module account_approval, one has restriction on the max discount allowed. 
See 👀  around: https://github.com/sbuhl/account_approval/blob/853d3329774a0c31747ae5147503a20d8277f97d/models/account_approval.py#L38

But, if the pricelist set a specific discount everyone should be allowed to use this discount

### Specification ♻️ 

Allow to validate any discount if the discount comes from a pricelist.

e.g., Discount of 90% on a product set on a pricelist, Marc demo should be able to validate it. 