### PR TITLE
[IMP]Cancel SO, no warning

### DIFF
--- a/gse_cancel_so_warnig/__init__.py
+++ b/gse_cancel_so_warnig/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/gse_cancel_so_warnig/__manifest__.py
+++ b/gse_cancel_so_warnig/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "GSE Cancel SO Warning",
+    "summary": """ Remove the warning popup when we cancel the Sale Order. """,
+    "version": "16.0.1.0.0",
+    "category": "Sale",
+    "website": "",
+    "author": "Magana Mwinja Asiati",
+    "license": "OPL-1",
+    "installable": True,
+    "application": False,
+    "depends": [
+        "sale",
+    ],
+    "data": [
+    ],
+}

--- a/gse_cancel_so_warnig/models/__init__.py
+++ b/gse_cancel_so_warnig/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import sale_order
+

--- a/gse_cancel_so_warnig/models/sale_order.py
+++ b/gse_cancel_so_warnig/models/sale_order.py
@@ -1,0 +1,10 @@
+from odoo import api, fields, models
+from odoo.addons.sale.models.sale_order import SaleOrder as OdooSaleOrder
+
+class SaleOrder(models.Model):
+    _inherit= 'sale.order'
+
+    def action_cancel(self):
+        return self._action_cancel()
+    
+    OdooSaleOrder.action_cancel = action_cancel


### PR DESCRIPTION
Rationale


Since version 16, whenever a Sales Order (SO) is canceled, a warning appears suggesting that an email should be sent to the customer. This feature is prone to errors.


![image](https://github.com/GoShop-Energy/lou/assets/95297251/5ca737f8-3050-48ac-83ce-114729cefaf8)


Specification

Deactivate this email and simply cancel the SO.