### PR TITLE
[IMP] Restriction of Tax Application to Selected Journals

### DIFF
--- a/gse_account/__manifest__.py
+++ b/gse_account/__manifest__.py
@@ -16,8 +16,10 @@
         "account",
     ],
     "data": [
-        "views/res_config_settings_views.xml",
+        "views/account_journal_views.xml",
+        "views/account_tax_views.xml",
         "views/account_views.xml",
+        "views/res_config_settings_views.xml",
         "reports/account_report_views.xml",
     ],
 }

--- a/gse_account/models/__init__.py
+++ b/gse_account/models/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
-from . import res_config_settings
-from . import company
+from . import account_journal
 from . import account_move
+from . import account_tax
+from . import company
+from . import res_config_settings

--- a/gse_account/models/account_journal.py
+++ b/gse_account/models/account_journal.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    allowed_taxes = fields.Many2many(
+        comodel_name="account.tax",
+        relation="account_tax_journal_rel",
+        column1="journal_id",
+        column2="tax_id",
+        string="Allowed Taxes",
+    )

--- a/gse_account/models/account_move.py
+++ b/gse_account/models/account_move.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo import fields, models, _
 from odoo.tools import get_lang
+from odoo.exceptions import ValidationError
 
 
 class AccountMove(models.Model):
@@ -8,6 +9,18 @@ class AccountMove(models.Model):
 
     use_custom_msg = fields.Boolean(string='Use Custom Message')
 
+    def action_post(self):
+        res = super(AccountMove, self).action_post()
+        move_line = self.env["account.move.line"].search([("move_id", "=", self.id)])
+        for line in move_line:
+            for tax in line.tax_ids:
+                transformed_args = [arg.id for arg in tax.allowed_journal]
+                if self.journal_id.id not in transformed_args and tax.allowed_journal:
+                    raise ValidationError(
+                        f"{tax.name} - This tax is not allowed for this journal : {self.journal_id.name}."
+                    )
+        return res
+    
     def _get_mail_template(self):
         """
         :return: the correct mail template based on the current move type and the alternate email template
@@ -17,3 +30,4 @@ class AccountMove(models.Model):
         if self.company_id.use_custom_msg and self.company_id.use_custom_msg and self.use_custom_msg and gse_template: 
             return next(iter(gse_template.get_external_id().values()), None)
         return res
+    

--- a/gse_account/models/account_tax.py
+++ b/gse_account/models/account_tax.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    allowed_journal = fields.Many2many("account.journal", string="Allowed Journals")

--- a/gse_account/views/account_journal_views.xml
+++ b/gse_account/views/account_journal_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_journal_tax_form" model="ir.ui.view">
+        <field name="name">account.journal.tax.form</field>
+        <field name="inherit_id" ref="account.view_account_journal_group_form"/>
+        <field name="priority">99</field>
+        <field name="model">account.journal</field>
+        <field name="arch" type="xml">
+            <xpath expr="//form//sheet//group//field[@name='company_id']" position="after">
+                <field name="allowed_taxes" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/gse_account/views/account_tax_views.xml
+++ b/gse_account/views/account_tax_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_tax_journal_form" model="ir.ui.view">
+                <field name="name">account.tax.journal.form</field>
+                <field name="inherit_id" ref="account.view_tax_form" />
+                <field name="priority">99</field>
+                <field name="model">account.tax</field>
+                <field name="arch" type="xml">
+                    <xpath expr="//form//sheet//group//group//field[@name='active']" position="after">
+                        <field name="allowed_journal" widget="many2many_tags"/>
+                    </xpath>
+                </field>
+    </record>
+</odoo>


### PR DESCRIPTION
On this branch, I made changes based on the description below.

Rationale 🎯 :

To enhance the accounting app by introducing a feature that allows limiting the use of specific taxes to selected journals. This feature will help in enforcing financial controls.

Specification 👀 :

Tax-Journal Linking:
A new Many2Many field shall be added to the tax configuration (in the Accounting module) to associate specific taxes with selected journals.
The field will be labeled as "Allowed Journals" and will list all available journals in the system for selection.

Default Behavior:
By default, if the "Allowed Journals" field is not populated for a tax, the system shall allow its use in all journals.

Invoice Validation Restriction:
During the validation of an invoice (not a Sales Order), the system shall check if the taxes applied on the invoice are permitted for the journal associated with the invoice.
If an invoice includes any tax that is not linked to the invoice's journal (i.e., the tax is not among the allowed taxes for that journal), the system shall prevent the validation of the invoice.
A clear error message shall be displayed, indicating the reason for the validation failure. The message should specify which tax(es) are not allowed for the journal.

User Interface Adjustments:
The user interface for tax configuration shall be adjusted to include the new "Allowed Journals" field.
Appropriate tooltips or help text shall be provided to guide users in using this new feature.

Reporting and Logging:
All attempts to validate invoices with unauthorized tax-journal combinations shall be logged for audit purposes.
The system shall provide reports to administrators showing instances of validation blocks due to this restriction.

Based on: https://github.com/GoShop-Energy/lou/pull/10
