### PR TITLE
[FIX] Handle res_ids as a list in PDF report generation

### DIFF
--- a/cloud_storage/cloud_storage/models/ir_actions_report.py
+++ b/cloud_storage/cloud_storage/models/ir_actions_report.py
@@ -1,10 +1,13 @@
 from odoo import models
 
-
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
     def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
+        # Assurez-vous que res_ids est une liste
+        if not isinstance(res_ids, list):
+            res_ids = [res_ids]
+        
         # move attachments for the given records after pdf creation
         # only not yet cloud attachments will be moved
         res = super()._render_qweb_pdf(report_ref, res_ids, data)


### PR DESCRIPTION
This fix ensures that the res_ids parameter is converted to a list if it is not already one. This prevents the "Invalid domain term" error when searching for attachments related to the generated PDF report.
