### PR TITLE
[IMP] gse_account_followup: Title Follow Up Reports

### DIFF
--- a/credit_management/__manifest__.py
+++ b/credit_management/__manifest__.py
@@ -7,7 +7,7 @@
         Credit management options with Partner Credit Hold/Credit Limit""",
     "author": "Sodexis",
     "website": "https://sodexis.com/",
-    "version": "16.0.3.0.1",
+    "version": "17.0.1.0",
     "installable": True,
     "license": "OPL-1",
     "depends": [

--- a/gse_account/__manifest__.py
+++ b/gse_account/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Benjamin Kisenge",
     "website": "https://dev--glowing-faun-e9789d.netlify.app",
     "category": "Customizations",
-    "version": "0.1.8.7",
+    "version": "17.0.1.0",
     "license": "LGPL-3",
     "depends": [
         "base",

--- a/gse_account_followup/__init__.py
+++ b/gse_account_followup/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/gse_account_followup/__manifest__.py
+++ b/gse_account_followup/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "GSE Account Followup",
+    "summary": """
+        Customisation of Account followup module for GoShop Energy""",
+    "description": """
+    """,
+    "author": "Magana Asiati",
+    "category": "Customizations",
+    "version": "17.0.1.0",
+    "license": "LGPL-3",
+    "depends": [
+        "account",
+        "account_followup",
+    ],
+    "data": [
+        "views/report_followup.xml",
+    ],
+}

--- a/gse_account_followup/models/__init__.py
+++ b/gse_account_followup/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import followup_manual_reminder

--- a/gse_account_followup/models/followup_manual_reminder.py
+++ b/gse_account_followup/models/followup_manual_reminder.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, api
+
+class FollowupManualReminder(models.TransientModel):
+    _inherit = 'account_followup.manual_reminder'
+
+    def process_followup(self):
+        """Add a condition to include template_id in the options.
+        """
+        action = super(FollowupManualReminder, self).process_followup()
+        options = self._get_wizard_options()
+        if self.template_id:
+            options['template_id'] = self.template_id
+        action = self.partner_id.execute_followup(options)
+        return action or {
+            'type': 'ir.actions.act_window_close',
+        }

--- a/gse_account_followup/views/report_followup.xml
+++ b/gse_account_followup/views/report_followup.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+     <template id="custom_template_followup_report" inherit_id="account_followup.template_followup_report">
+        <xpath expr="//div[@class='print_only']//h2/strong" position="replace">
+                <strong>
+                 <t t-if="options.get('template_id')">
+                    <t t-esc="options['template_id'].name"/>
+                 </t>
+                </strong>
+        </xpath>
+    </template>
+</odoo>

--- a/gse_analytic/__manifest__.py
+++ b/gse_analytic/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "GSE Analytic",
     "category": "Customizations",
-    "version": "1.0",
+    "version": "17.0.1.0",
     "license": "LGPL-3",
     "depends": [
         "account",

--- a/gse_industry_fsm/__manifest__.py
+++ b/gse_industry_fsm/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Benjamin Kisenge",
     "website": "https://github.com/GoShop-Energy/field-service",
     "category": "Customizations",
-    "version": "0.1.8.7",
+    "version": "17.0.1.0",
     "license": "LGPL-3",
     "depends": [
         "base",

--- a/gse_website_sale_stock/__manifest__.py
+++ b/gse_website_sale_stock/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Sébastien Bühl",
     'website': "http://www.buhl.be",
     'category': 'Customizations',
-    'version': '0.1',
+    'version': '17.0.1.0',
     'license': 'LGPL-3',
 
     # any module necessary for this one to work correctly

--- a/sod_sale_payment_method/__manifest__.py
+++ b/sod_sale_payment_method/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Payment Method ",
     "summary": """Adds the payment method on the Customer and the Sale Order. """,
-    "version": "16.0.1.0.0",
+    "version": "17.0.1.0",
     "category": "Sale",
     "website": "https://sodexis.com/",
     "author": "Sodexis",

--- a/technicians/__manifest__.py
+++ b/technicians/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Transport Bonuses GSE',
     'author': "Sébastien Bühl, Shortcut1337",
     'website': "http://www.goshop.energy",
-    'version': '0.1',
+    'version': '17.0.1.0',
     'category': 'Hidden',
     'license': 'LGPL-3',
     'summary': 'Transport Expenses for Technicians and Project Manager',


### PR DESCRIPTION
## [IMP] Title Follow Up Reports

Rationale: Présenter le nom du follow up report dans le rapport imprimé.

Pour reproduire:

Aller dans Follow Up Report
Cliquer sur un client
Cliquer sur Follow Up
Imprimer le Report
![image](https://github.com/user-attachments/assets/6a4a6671-5c2d-4ff1-a35d-712e1ca126ea)
Le titre du rapport est 'Pending Invoices':
![image](https://github.com/user-attachments/assets/da42e1a6-41ab-4e3e-8254-efe2bd7f8898)


Le titre devrait être celui du Mail Template


![image](https://github.com/user-attachments/assets/5de2794f-3c1c-4305-a399-34badd0e53e3)

