### PR TITLE
[IMP] Ajout Ligne Projet si devis > 50k

### DIFF
--- a/cloud_storage/cloud_storage/__manifest__.py
+++ b/cloud_storage/cloud_storage/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "Cloud Storage",
     "summary": """Store chatter attachments in the cloud (Google or Azure)""",
     "category": "Technical Settings",
-    "version": "1.1.0",
+    "version": "17.0.1.0",
     "depends": ["base"],
     "data": [
         "views/settings.xml",

--- a/cloud_storage/cloud_storage_testing/__manifest__.py
+++ b/cloud_storage/cloud_storage_testing/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "Cloud Storage Testing",
     "summary": """Additional testing module, to be used with cloud storage emulators""",
     "category": "Technical Settings",
-    "version": "1.0.0",
+    "version": "17.0.1.0",
     "depends": ["cloud_storage"],
     "data": [
     ],

--- a/credit_management/__manifest__.py
+++ b/credit_management/__manifest__.py
@@ -7,7 +7,7 @@
         Credit management options with Partner Credit Hold/Credit Limit""",
     "author": "Sodexis",
     "website": "https://sodexis.com/",
-    "version": "16.0.3.0.1",
+    "version": "17.0.1.0",
     "installable": True,
     "license": "OPL-1",
     "depends": [

--- a/gse_account/__manifest__.py
+++ b/gse_account/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Benjamin Kisenge",
     "website": "https://dev--glowing-faun-e9789d.netlify.app",
     "category": "Customizations",
-    "version": "0.1.8.7",
+    "version": "17.0.1.0",
     "license": "LGPL-3",
     "depends": [
         "base",

--- a/gse_analytic/__manifest__.py
+++ b/gse_analytic/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "GSE Analytic",
     "category": "Customizations",
-    "version": "1.0",
+    "version": "17.0.1.0",
     "license": "LGPL-3",
     "depends": [
         "account",

--- a/gse_industry_fsm/__manifest__.py
+++ b/gse_industry_fsm/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Benjamin Kisenge",
     "website": "https://github.com/GoShop-Energy/field-service",
     "category": "Customizations",
-    "version": "0.1.8.7",
+    "version": "17.0.1.0",
     "license": "LGPL-3",
     "depends": [
         "base",

--- a/gse_sale/__init__.py
+++ b/gse_sale/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import models
+from . import wizard

--- a/gse_sale/__manifest__.py
+++ b/gse_sale/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "GSE sale",
+    "summary": """
+        Customisation of Account module for GoShop Energy""",
+    "description": """
+    """,
+    "author": "Benjamin Kisenge",
+    "website": "https://dev--glowing-faun-e9789d.netlify.app",
+    "category": "Customizations",
+    "version": "17.0.1.0",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "sale",
+    ],
+    "data": [
+        "views/warning_wizard_view.xml",
+        'security/ir.model.access.csv',
+    ],
+}

--- a/gse_sale/models/__init__.py
+++ b/gse_sale/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import sale_order

--- a/gse_sale/models/sale_order.py
+++ b/gse_sale/models/sale_order.py
@@ -8,14 +8,13 @@ class SaleOrder(models.Model):
     def action_confirm(self):
         for order in self:
             if self.env.context.get('force_confirm', False):
-                # Proceed with the standard confirmation process
                 return super(SaleOrder, self).action_confirm()
+
             if order.amount_total > 50000:
-                # Vérifier si un produit de type "Project Main d'Oeuvre" est présent
                 has_project_mo_product = any(line.product_id.type == 'service' for line in order.order_line)
                 
                 if not has_project_mo_product:
-                    # Appeler le wizard avec un message et une input
+                    # Trigger the wizard
                     return {
                         'name': 'Montant supérieur à 50k',
                         'type': 'ir.actions.act_window',
@@ -28,8 +27,6 @@ class SaleOrder(models.Model):
                         }
                     }
                 else:
-                    # Validation classique si "Project Main d'Oeuvre" est présent
                     return super(SaleOrder, self).action_confirm()
             else:
-                # Validation classique si le montant est inférieur à 50k
                 return super(SaleOrder, self).action_confirm()

--- a/gse_sale/models/sale_order.py
+++ b/gse_sale/models/sale_order.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+from odoo.exceptions import UserError
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def action_confirm(self):
+        for order in self:
+            if self.env.context.get('force_confirm', False):
+                # Proceed with the standard confirmation process
+                return super(SaleOrder, self).action_confirm()
+            if order.amount_total > 50000:
+                # Vérifier si un produit de type "Project Main d'Oeuvre" est présent
+                has_project_mo_product = any(line.product_id.type == 'service' for line in order.order_line)
+                
+                if not has_project_mo_product:
+                    # Appeler le wizard avec un message et une input
+                    return {
+                        'name': 'Montant supérieur à 50k',
+                        'type': 'ir.actions.act_window',
+                        'res_model': 'warning.wizard',
+                        'view_mode': 'form',
+                        'target': 'new',
+                        'view_id': self.env.ref('gse_sale.warning_wizard_form').id,
+                        'context': {
+                            'default_sale_order_id': self.id
+                        }
+                    }
+                else:
+                    # Validation classique si "Project Main d'Oeuvre" est présent
+                    return super(SaleOrder, self).action_confirm()
+            else:
+                # Validation classique si le montant est inférieur à 50k
+                return super(SaleOrder, self).action_confirm()

--- a/gse_sale/security/ir.model.access.csv
+++ b/gse_sale/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_warning_wizard,access_warning_wizard,model_warning_wizard,,1,1,1,

--- a/gse_sale/views/warning_wizard_view.xml
+++ b/gse_sale/views/warning_wizard_view.xml
@@ -3,7 +3,7 @@
         <field name="name">warning.wizard.form</field>
         <field name="model">warning.wizard</field>
         <field name="arch" type="xml">
-            <form string="Le montant de votre devis est supérieur à 50k, voulez-vous ajouter une ligne project Main d'oeuvre">
+            <form string="Le montant de votre devis est supérieur à 50k">
                 <group>
                     <field name="confirm" widget="radio"/>
                     <field name="additional_amount" modifiers="{'invisible': [('confirm', '!=', 'yes')]}"/>
@@ -16,3 +16,5 @@
         </field>
     </record>
 </odoo>
+
+

--- a/gse_sale/views/warning_wizard_view.xml
+++ b/gse_sale/views/warning_wizard_view.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <record id="warning_wizard_form" model="ir.ui.view">
+        <field name="name">warning.wizard.form</field>
+        <field name="model">warning.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Le montant de votre devis est supérieur à 50k, voulez-vous ajouter une ligne project Main d'oeuvre">
+                <group>
+                    <field name="confirm" widget="radio"/>
+                    <field name="additional_amount" modifiers="{'invisible': [('confirm', '!=', 'yes')]}"/>
+                </group>
+                <footer>
+                    <button string="Confirmer" type="object" name="action_confirm_warning" class="btn-primary"/>
+                    <button string="Annuler" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/gse_sale/wizard/__init__.py
+++ b/gse_sale/wizard/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import warning_wizard

--- a/gse_sale/wizard/warning_wizard.py
+++ b/gse_sale/wizard/warning_wizard.py
@@ -6,17 +6,25 @@ class WarningWizard(models.TransientModel):
      
     sale_order_id = fields.Many2one('sale.order', string="Sale Order", required=True)
     confirm = fields.Selection([('yes', 'Oui'), ('no', 'Non')], string="Confirmer?", required=True)
-    additional_amount = fields.Float(string="Montant supplémentaire")
+    additional_amount = fields.Float(string="Montant supplémentaire", help="Montant à ajouter si 'Oui' est sélectionné")
 
     def action_confirm_warning(self):
         sale_order = self.sale_order_id
-        if self.confirm == 'yes':
-            # Logique pour ajouter le montant supplémentaire ou autre action
-            if self.additional_amount:
-                sale_order.amount_total += self.additional_amount
-            # Ajouter d'autres actions si nécessaire
-        else:
-            # Si la confirmation est "Non", on confirme directement le Sale Order
-             return sale_order.with_context({'force_confirm': True}).action_confirm()
         
-        return {'type': 'ir.actions.act_window_close'}
+        if self.confirm == 'yes':
+            service_product = self.env['product.product'].search([('name', '=', 'Project Main d\'Oeuvre')], limit=1)
+            if not service_product:
+                raise UserError("Le produit 'Project Main d'Oeuvre' n'existe pas. Veuillez le créer.")
+            
+            # Add the product to the sale order with the specified price from the widget
+            sale_order.write({
+                'order_line': [(0, 0, {
+                    'product_id': service_product.id,
+                    'name': service_product.name,
+                    'product_uom_qty': 1,
+                    'price_unit': self.additional_amount or service_product.lst_price,  # Use input price or default product price
+                })]
+            })
+            
+        # Proceed with the sale order confirmation
+        return sale_order.with_context({'force_confirm': True}).action_confirm()

--- a/gse_sale/wizard/warning_wizard.py
+++ b/gse_sale/wizard/warning_wizard.py
@@ -1,0 +1,22 @@
+from odoo import models, fields, api
+
+class WarningWizard(models.TransientModel):
+    _name = 'warning.wizard'
+    _description = 'Warning for SO over 50k'
+     
+    sale_order_id = fields.Many2one('sale.order', string="Sale Order", required=True)
+    confirm = fields.Selection([('yes', 'Oui'), ('no', 'Non')], string="Confirmer?", required=True)
+    additional_amount = fields.Float(string="Montant supplémentaire")
+
+    def action_confirm_warning(self):
+        sale_order = self.sale_order_id
+        if self.confirm == 'yes':
+            # Logique pour ajouter le montant supplémentaire ou autre action
+            if self.additional_amount:
+                sale_order.amount_total += self.additional_amount
+            # Ajouter d'autres actions si nécessaire
+        else:
+            # Si la confirmation est "Non", on confirme directement le Sale Order
+             return sale_order.with_context({'force_confirm': True}).action_confirm()
+        
+        return {'type': 'ir.actions.act_window_close'}

--- a/gse_website_sale_stock/__manifest__.py
+++ b/gse_website_sale_stock/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Sébastien Bühl",
     'website': "http://www.buhl.be",
     'category': 'Customizations',
-    'version': '0.1',
+    'version': '17.0.1.0',
     'license': 'LGPL-3',
 
     # any module necessary for this one to work correctly

--- a/sod_sale_payment_method/__manifest__.py
+++ b/sod_sale_payment_method/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Payment Method ",
     "summary": """Adds the payment method on the Customer and the Sale Order. """,
-    "version": "16.0.1.0.0",
+    "version": "17.0.1.0",
     "category": "Sale",
     "website": "https://sodexis.com/",
     "author": "Sodexis",

--- a/technicians/__manifest__.py
+++ b/technicians/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Transport Bonuses GSE',
     'author': "Sébastien Bühl, Shortcut1337",
     'website': "http://www.goshop.energy",
-    'version': '0.1',
+    'version': '17.0.1.0',
     'category': 'Hidden',
     'license': 'LGPL-3',
     'summary': 'Transport Expenses for Technicians and Project Manager',


### PR DESCRIPTION
# [IMP] Ajout Ligne Projet si devis > 50k

## Rationale:

Les vendeurs "oublient" souvent d'ajouter une ligne de projet si leur devis est supérieur à 50k, 

Or, pour les gros projets, le suivi de l'installation doit créer un projet pour un meilleur suivi.

## Specification:

A la confirmation d'un SO, vérifier si le montant du SO est > 50k, 
	​S'il est supérieur, 
	​	​vérifier les lignes du SO, est-ce qu'elles contiennent un produit de type "Project Main d'Oeuvre"
	​	​	​Si oui, validation classique
	​	​	​Si non, ajouter dans le warning, un radio button + message " Le montant de votre devis est supérieur à 50k, voulez-vous..." + si on sélectionne oui, ajouter un input avec le montant de ce produit
	​Sinon, validation classique avec le warning de confirmation normal

![image](https://github.com/user-attachments/assets/541606f1-185e-4851-959e-d0d8ac48ee52)
