### PR TITLE
Gse budget progression assia

### DIFF
--- a/credit_management/__manifest__.py
+++ b/credit_management/__manifest__.py
@@ -7,7 +7,7 @@
         Credit management options with Partner Credit Hold/Credit Limit""",
     "author": "Sodexis",
     "website": "https://sodexis.com/",
-    "version": "16.0.3.0.1",
+    'version': '17.0.1.0',
     "installable": True,
     "license": "OPL-1",
     "depends": [

--- a/gse_account/__manifest__.py
+++ b/gse_account/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Benjamin Kisenge",
     "website": "https://dev--glowing-faun-e9789d.netlify.app",
     "category": "Customizations",
-    "version": "0.1.8.7",
+    "version": "17.0.1.0",
     "license": "LGPL-3",
     "depends": [
         "base",

--- a/gse_analytic/__manifest__.py
+++ b/gse_analytic/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "GSE Analytic",
     "category": "Customizations",
-    "version": "1.0",
+    'version': '17.0.1.0',
     "license": "LGPL-3",
     "depends": [
         "account",

--- a/gse_budget_position/__init__.py
+++ b/gse_budget_position/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/gse_budget_position/__manifest__.py
+++ b/gse_budget_position/__manifest__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+{
+    "name": "GSE Budget Position",
+    "summary": """
+        Customisation of Account module for GoShop Energy""",
+    "description": """
+    """,
+    "author": "Benjamin Kisenge",
+    "website": "https://dev--glowing-faun-e9789d.netlify.app",
+    "category": "Customizations",
+    "version": "17.0.1.0",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "account",
+        "account_budget",
+        "analytic"
+    ],
+    "data": [
+        "views/account_analytic_line_view.xml",
+    
+    ],
+}

--- a/gse_budget_position/models/__init__.py
+++ b/gse_budget_position/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from . import account_analytic_line
 from . import account_budget
+from . import timesheets_analytic_report
 
 

--- a/gse_budget_position/models/__init__.py
+++ b/gse_budget_position/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from . import account_analytic_line
+from . import account_budget
+
+

--- a/gse_budget_position/models/account_analytic_line.py
+++ b/gse_budget_position/models/account_analytic_line.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields
+
+class AccountAnalyticLine(models.Model):
+    _inherit = 'account.analytic.line'
+
+    general_budget_id = fields.Many2one(
+        'crossovered.budget.lines', 
+        string='Budgetary Position',
+        ondelete='set null',
+        help="The budgetary position related to this analytic line."
+    )

--- a/gse_budget_position/models/account_analytic_line.py
+++ b/gse_budget_position/models/account_analytic_line.py
@@ -8,5 +8,8 @@ class AccountAnalyticLine(models.Model):
         'crossovered.budget.lines', 
         string='Budgetary Position',
         ondelete='set null',
+        store=True,  # Optional: if you want to store the field in the database
         help="The budgetary position related to this analytic line."
     )
+
+    

--- a/gse_budget_position/models/account_budget.py
+++ b/gse_budget_position/models/account_budget.py
@@ -8,3 +8,4 @@ class CrossoveredBudgetLines(models.Model):
         'general_budget_id', 
         string="Analytic Lines"
     )
+

--- a/gse_budget_position/models/account_budget.py
+++ b/gse_budget_position/models/account_budget.py
@@ -1,0 +1,10 @@
+from odoo import models, fields
+
+class CrossoveredBudgetLines(models.Model):
+    _inherit = 'crossovered.budget.lines'
+
+    analytic_line_ids = fields.One2many(
+        'account.analytic.line', 
+        'general_budget_id', 
+        string="Analytic Lines"
+    )

--- a/gse_budget_position/models/timesheets_analytic_report.py
+++ b/gse_budget_position/models/timesheets_analytic_report.py
@@ -1,0 +1,11 @@
+from odoo import models, fields
+
+class TimesheetsAnalysisReport(models.Model):
+    _name = 'timesheets.analysis.report'
+    _inherit = 'timesheets.analysis.report'  
+
+    general_budget_id = fields.Many2one('crossovered.budget.lines', string='General Budget')
+
+    def _compute_general_budget_id(self):
+        for record in self:
+            record.general_budget_id = record.analytic_account_id.general_budget_id

--- a/gse_budget_position/views/account_analytic_line_view.xml
+++ b/gse_budget_position/views/account_analytic_line_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Inherit and extend the groupby section in account.analytic.line filter view -->
+    <record id="view_account_analytic_line_filter_inherit_custom" model="ir.ui.view">
+        <field name="name">account.analytic.line.select.inherit.custom</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_line_filter"/>
+        <field name="arch" type="xml">
+            <!-- Insert the general_budget_id filter in the groupby section -->
+            <xpath expr="//group[@name='groupby']" position="inside">
+                <separator/>
+                <!-- Add filter for Budgetary Position -->
+                <filter string="Budgetary Position" name="group_by_budgetary_position" context="{'group_by':'general_budget_id'}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_account_analytic_line_tree_inherit" model="ir.ui.view">
+        <field name="name">account.analytic.line.tree.inherit</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_line_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <!-- Add Budgetary Position (general_budget_id) -->
+                <field name="general_budget_id" optional="show"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>
+

--- a/gse_budget_position/views/account_analytic_line_view.xml
+++ b/gse_budget_position/views/account_analytic_line_view.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- Inherit and extend the groupby section in account.analytic.line filter view -->
     <record id="view_account_analytic_line_filter_inherit_custom" model="ir.ui.view">
         <field name="name">account.analytic.line.select.inherit.custom</field>
         <field name="model">account.analytic.line</field>
         <field name="inherit_id" ref="analytic.view_account_analytic_line_filter"/>
         <field name="arch" type="xml">
-            <!-- Insert the general_budget_id filter in the groupby section -->
             <xpath expr="//group[@name='groupby']" position="inside">
                 <separator/>
-                <!-- Add filter for Budgetary Position -->
                 <filter string="Budgetary Position" name="group_by_budgetary_position" context="{'group_by':'general_budget_id'}"/>
             </xpath>
         </field>
@@ -21,10 +18,18 @@
         <field name="inherit_id" ref="analytic.view_account_analytic_line_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">
-                <!-- Add Budgetary Position (general_budget_id) -->
                 <field name="general_budget_id" optional="show"/>
             </xpath>
         </field>
     </record>
+    <record id="view_account_analytic_line_form_inherit" model="ir.ui.view">
+        <field name="name">account.analytic.line.form.inherit.budget</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_line_form"/>
+        <field name="arch" type="xml">
+            <field name="account_id" position="after">
+                <field name="general_budget_id" string="Budget Position" readonly="0"/>
+            </field>
+        </field>
+    </record>
 </odoo>
-

--- a/gse_industry_fsm/__manifest__.py
+++ b/gse_industry_fsm/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Benjamin Kisenge",
     "website": "https://github.com/GoShop-Energy/field-service",
     "category": "Customizations",
-    "version": "0.1.8.7",
+    "version": "17.0.1.0",
     "license": "LGPL-3",
     "depends": [
         "base",

--- a/gse_website_sale_stock/__manifest__.py
+++ b/gse_website_sale_stock/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Sébastien Bühl",
     'website': "http://www.buhl.be",
     'category': 'Customizations',
-    'version': '0.1',
+    'version': '17.0.1.0',
     'license': 'LGPL-3',
 
     # any module necessary for this one to work correctly

--- a/sod_sale_payment_method/__manifest__.py
+++ b/sod_sale_payment_method/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Payment Method ",
     "summary": """Adds the payment method on the Customer and the Sale Order. """,
-    "version": "16.0.1.0.0",
+    "version": "17.0.1.0",
     "category": "Sale",
     "website": "https://sodexis.com/",
     "author": "Sodexis",

--- a/technicians/__manifest__.py
+++ b/technicians/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Transport Bonuses GSE',
     'author': "Sébastien Bühl, Shortcut1337",
     'website': "http://www.goshop.energy",
-    'version': '0.1',
+    'version': '17.0.1.0',
     'category': 'Hidden',
     'license': 'LGPL-3',
     'summary': 'Transport Expenses for Technicians and Project Manager',


### PR DESCRIPTION
Rationale
Actuellement, les budgets liés aux projets ne permettent qu'une lecture instantanée de leur état à un moment précis. 

e.g. Définition du budget


![image](https://github.com/user-attachments/assets/373170ee-e8b9-4e97-9fe1-f7f783fb2853)



Il est impossible de visualiser la progression de l'utilisation du budget au fil du temps par rapport aux positions budgétaires définies (crossovered.budget.lines).

![image](https://github.com/user-attachments/assets/9be8713b-4076-406a-89e7-e9dc19a8bebd)


Lorsque l'on consulte les Entrées (account.analytic.line), la lecture des positions budgétaires est perdue, rendant difficile le suivi de l'évolution budgétaire par ces positions, .

![image](https://github.com/user-attachments/assets/699733d4-b453-4afc-b56b-bd5e3eb44cd7)


alors que l'on peut la voir à travers les comptes financiers (financial accounts)

![image](https://github.com/user-attachments/assets/24070497-8d73-4877-8916-efffdaa49bff)

Cela pose problème car plusieurs comptes financiers peuvent être regroupés sous une même position budgétaire, rendant la gestion et le suivi complexe. 

![image](https://github.com/user-attachments/assets/0688dd92-4146-4a34-a08a-c44855042b42)


Objectif de la tâche
Développer une fonctionnalité permettant de visualiser la progression des budgets liés aux projets dans le temps, en se basant sur les positions budgétaires et non uniquement sur les comptes financiers.

Spécification fonctionnelle
Ajout du champ general_budget_id sur le modèle account.analytic.line



