### PR TITLE
[FIX] technicians: rounding issue on timesheets

### DIFF
--- a/technicians/models/bonus.py
+++ b/technicians/models/bonus.py
@@ -186,10 +186,12 @@ class Bonus(models.Model):
                     'order_id': timesheet.order_id.id,
                 })
                 bonus.add_bonus_on_vendor_bill()
-                involved_employees |= timesheet.employee_id
+                involved_employees |= timesheet.employee_id            
 
-            # Safety check
-            assert task_total_hours == total_timesheet_unit_amount, "Total hours spent on task does not match timesheet sum."
+            logger.info("Task total hours: %s, Timesheet total unit amount: %s for Task %s", task_total_hours, total_timesheet_unit_amount, labor_task.name)
+
+            if float_compare(task_total_hours, total_timesheet_unit_amount, precision_digits=precision) != 0:
+                raise UserError("Total hours spent on task does not match timesheet sum (rounded values).")
 
         # Generate bonus for every transport products
         if involved_employees:


### PR DESCRIPTION
### Issue:
In certain cases, the total hours spent on a task (`task_total_hours`) and the sum of timesheet hours (`total_timesheet_unit_amount`) have minor differences due to rounding, causing an AssertionError when generating bonuses for timesheet-related tasks.

### Solution:
Replaced the direct comparison of `task_total_hours` and `total_timesheet_unit_amount` with `float_compare`, allowing a comparison with the necessary precision to avoid rounding errors. The precision used is based on the `Product Unit of Measure` setting in Odoo.

### Impact:
This fix ensures that small rounding differences between task total hours and timesheet entries do not raise unnecessary errors when generating bonuses for timesheets.
